### PR TITLE
PATCH: Switch buzzer back to pwmio - non functional on audiopwmio

### DIFF
--- a/src/managers/buzzer_manager.py
+++ b/src/managers/buzzer_manager.py
@@ -2,36 +2,137 @@
 """
 Manages a passive piezo buzzer for hardware alerts and simple UI feedback.
 """
-import audiopwmio
-from managers.synth_manager import SynthManager
-from utilities.synth_registry import Waveforms
+import asyncio
+import pwmio
+
+from utilities import tones
 
 class BuzzerManager:
     """Manages a passive piezo buzzer using PWM and asyncio."""
 
     # Note Frequencies (Hz)
-    def __init__(self, pin):
-        # Setup Hardware
-        self.audio = audiopwmio.PWMAudioOut(pin)
+    def __init__(self, pin, volume=0.5, testing=False):
+        # Initialize PWM with 0 duty cycle (silence)
+        # Variable frequency is required for changing tones
+        self.testing = testing
+        self.buzzer = pwmio.PWMOut(pin, duty_cycle=0, frequency=440, variable_frequency=True)
+        self._current_task = None
 
-        # Setup Logic (The Synth Manager)
-        self.engine = SynthManager(
-            sample_rate=22050,
-            channel_count=1,
-            waveform_override=Waveforms.SQUARE
-        )
+        # Standard Duty Cycle (50% is max volume for a piezo)
+        if volume < 0.0 or volume > 1.0:
+            raise ValueError("Volume must be between 0.0 and 1.0")
 
-        self.audio.play(self.engine.source)
+        self.VOLUME_ON = int(volume * 2**16) - 1
+        self.VOLUME_OFF = 0
 
     def stop(self):
         """Immediately silences the buzzer and cancels running tasks."""
-        self.engine.release_all()
+        if self._current_task and not self._current_task.done():
+            self._current_task.cancel()
+
+        self.buzzer.duty_cycle = self.VOLUME_OFF
+
+    async def _play_tone_logic(self, frequency, duration=None):
+        """Internal logic to play a single tone."""
+        try:
+            self.buzzer.frequency = frequency
+            self.buzzer.duty_cycle = self.VOLUME_ON
+            if duration is not None and duration > 0:
+                await asyncio.sleep(duration)
+        except asyncio.CancelledError:
+            self.buzzer.duty_cycle = self.VOLUME_OFF
+        finally:
+            if duration is not None and duration > 0:
+                self.buzzer.duty_cycle = self.VOLUME_OFF
+
+    async def _play_sequence_logic(self, sequence, tempo=1.0, loop=False):
+        """
+        Internal logic to play a list of (frequency, duration) tuples.
+        tempo: Speed multiplier (1.0 = normal, 0.5 = double speed)
+        """
+        try:
+            while True:
+                for freq, dur in sequence:
+                    freq_rounded = int(round(freq))
+                    if self.testing:
+                        print(f"Playing freq: {freq_rounded} Hz for {dur} sec")
+                    if freq <= 0:
+                        self.buzzer.duty_cycle = self.VOLUME_OFF
+                    else:
+                        self.buzzer.frequency = freq_rounded
+                        self.buzzer.duty_cycle = self.VOLUME_ON
+
+                    await asyncio.sleep(dur * tempo)
+
+                    # Tiny gap between notes for articulation
+                    self.buzzer.duty_cycle = self.VOLUME_OFF
+                    await asyncio.sleep(0.01)
+
+                if not loop:
+                    break
+
+                await asyncio.sleep(0.1)  # Short pause before repeating
+
+                self.buzzer.duty_cycle = self.VOLUME_OFF
+
+        except asyncio.CancelledError:
+            self.buzzer.duty_cycle = self.VOLUME_OFF
+        except ValueError:
+            self.buzzer.duty_cycle = self.VOLUME_OFF
+
+    # --- PUBLIC TRIGGERS ---
+
+    def _play_tone(self, frequency, duration=None):
+        """Plays a single non-blocking tone."""
+        self.stop() # Preempt any existing sound
+        self._current_task = asyncio.create_task(
+            self._play_tone_logic(frequency, duration)
+        )
+
+    def _play_sequence(self, sequence, tempo=1.0, loop=False):
+        """Plays a sequence of notes [(freq, dur), ...]."""
+        self.stop()
+        self._current_task = asyncio.create_task(
+            self._play_sequence_logic(sequence, tempo, loop)
+        )
 
     def play_note(self, frequency, duration=None):
-        """Plays a single non-blocking tone."""
-        # Delegate logic to the engine
-        self.engine.play_note(frequency, duration=duration)
+        """Public method to play a single note."""
+        self._play_tone(frequency, duration)
 
-    def play_sequence(self, sequence_data):
-        """Plays a sequence of notes [(freq, dur), ...]."""
-        self.engine.play_sequence(sequence_data)
+    def play_sequence(self, sequence_data, loop=None):
+        """Plays a sequence in JEB tones format."""
+
+        # Handle string input for convenience
+        if isinstance(sequence_data, str):
+            # Normalize to uppercase to be safe
+            song_name = sequence_data.upper()
+
+            # Check if this exists in the imported 'tones' library
+            if hasattr(tones, song_name):
+                sequence_data = getattr(tones, song_name)
+            else:
+                print(f"🔊 BuzzerManager Warning: Song '{song_name}' not found in tones.py")
+                return
+
+        if not isinstance(sequence_data, dict):
+            return
+
+        bpm = sequence_data.get('bpm',120)
+        sequence = sequence_data.get('sequence', [])
+
+        should_loop = loop if loop is not None else sequence_data.get('loop', False)
+
+        print(f"Playing song at {bpm} BPM with {len(sequence)} notes.")
+
+        # Calculate beat duration in seconds
+        beat_duration = 60.0 / bpm
+
+        # Convert sequence to (frequency, duration in seconds)
+        seq_converted = []
+        for note_name, beat_length in sequence:
+            freq = tones.note(note_name)
+            dur = beat_length * beat_duration
+            seq_converted.append((freq, dur))
+
+        self._play_sequence(seq_converted, tempo=1.0, loop=should_loop)


### PR DESCRIPTION
This pull request significantly refactors the `BuzzerManager` class in `src/managers/buzzer_manager.py` to use asyncio and direct PWM control for improved buzzer management, replacing the previous audio and synth-based approach which proved to be non-functional for piezos. The update introduces asynchronous, non-blocking playback for tones and sequences, adds support for playing named tone sequences from a shared `tones` module, and provides better handling for volume, looping, and testing.

Key changes include:

**Refactoring and Hardware Control:**
* Replaced the use of `audiopwmio.PWMAudioOut` and `SynthManager` with direct control of the buzzer using `pwmio.PWMOut`, allowing for variable frequency and duty cycle manipulation for tone generation.
* Introduced volume control with input validation and set up standard duty cycles for the buzzer.

**Async Playback and Task Management:**
* Implemented asynchronous methods (`_play_tone_logic`, `_play_sequence_logic`) to play tones and sequences without blocking, using `asyncio.create_task` for concurrent operation and proper cancellation of previous sounds.
* Added logic to safely stop and cancel ongoing buzzer tasks, ensuring clean transitions between sounds.

**Sequence and Note Playback Enhancements:**
* Added support for playing named sequences by looking them