### PR TITLE
Fetch latest Adafruit Bundle URL dynamically

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -78,8 +78,17 @@ jobs:
           cp -r src/transport $STAGE_DIR/ || true
           cp -r src/utilities $STAGE_DIR/ || true
 
-          echo "--> Downloading Adafruit Source Bundle..."
-          wget https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest/download/adafruit-circuitpython-bundle-py-latest.zip -O /tmp/bundle.zip
+          echo "--> Fetching latest Adafruit Bundle URL..."
+          # Query the GitHub API to find the exact dynamic URL for the -py- bundle
+          BUNDLE_URL=$(curl -s https://api.github.com/repos/adafruit/Adafruit_CircuitPython_Bundle/releases/latest | jq -r '.assets[] | select(.name | contains("-py-")) | .browser_download_url')
+          
+          if [ -z "$BUNDLE_URL" ]; then
+            echo "ERROR: Failed to fetch the bundle URL from GitHub API."
+            exit 1
+          fi
+          
+          echo "Downloading from: $BUNDLE_URL"
+          wget -q "$BUNDLE_URL" -O /tmp/bundle.zip
           unzip -q /tmp/bundle.zip -d /tmp/bundle_extracted
 
           # Find the nested 'lib' folder inside the extracted bundle

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -80,7 +80,7 @@ jobs:
 
           echo "--> Fetching latest Adafruit Bundle URL..."
           # Query the GitHub API to find the exact dynamic URL for the -py- bundle
-          BUNDLE_URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/adafruit/Adafruit_CircuitPython_Bundle/releases/latest | jq -r '.assets[] | select(.name | contains("-py-")) | .browser_download_url')
+          BUNDLE_URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/adafruit/Adafruit_CircuitPython_Bundle/releases/latest | jq -r '.assets[] | select(.name | contains("-py-")) | select(.name | endswith(".zip")) | .browser_download_url')
           
           if [ -z "$BUNDLE_URL" ]; then
             echo "ERROR: Failed to fetch the bundle URL from GitHub API."

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -80,7 +80,7 @@ jobs:
 
           echo "--> Fetching latest Adafruit Bundle URL..."
           # Query the GitHub API to find the exact dynamic URL for the -py- bundle
-          BUNDLE_URL=$(curl -s https://api.github.com/repos/adafruit/Adafruit_CircuitPython_Bundle/releases/latest | jq -r '.assets[] | select(.name | contains("-py-")) | .browser_download_url')
+          BUNDLE_URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/adafruit/Adafruit_CircuitPython_Bundle/releases/latest | jq -r '.assets[] | select(.name | contains("-py-")) | .browser_download_url')
           
           if [ -z "$BUNDLE_URL" ]; then
             echo "ERROR: Failed to fetch the bundle URL from GitHub API."


### PR DESCRIPTION
Updated the firmware build workflow to dynamically fetch the latest Adafruit CircuitPython Bundle URL using the GitHub API instead of a static link.